### PR TITLE
Update Cabana exchange links across DAO and Labs pages to use partner…

### DIFF
--- a/src/app/dao/page.tsx
+++ b/src/app/dao/page.tsx
@@ -45,7 +45,7 @@ export default function DAOPage() {
                   size="lg" 
                   variant="outline"
                   className="transition-all duration-300 hover:scale-95 flex items-center"
-                  onClick={() => window.open('https://cabana.exchange/swap/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v-LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR?daoRef=Epicentral', '_blank')}
+                  onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank')}
                 >
                   <Image 
                     src="/cabana_logo.png" 
@@ -445,7 +445,7 @@ export default function DAOPage() {
                     </DropdownMenuItem>
                     <DropdownMenuItem 
                       className="text-white hover:bg-white/10 focus:bg-white/10 cursor-pointer flex items-center"
-                      onClick={() => window.open('https://cabana.exchange/swap/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v-LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR?daoRef=Epicentral', '_blank')}
+                      onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank')}
                     >
                       <Image 
                         src="/cabana_logo.png" 

--- a/src/app/dao/page.tsx
+++ b/src/app/dao/page.tsx
@@ -45,7 +45,7 @@ export default function DAOPage() {
                   size="lg" 
                   variant="outline"
                   className="transition-all duration-300 hover:scale-95 flex items-center"
-                  onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank')}
+                  onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank', 'noopener,noreferrer')}
                 >
                   <Image 
                     src="/cabana_logo.png" 

--- a/src/app/labs-token/page.tsx
+++ b/src/app/labs-token/page.tsx
@@ -217,7 +217,7 @@ if (!isMounted) {
                   </DropdownMenuItem>
                   <DropdownMenuItem 
                     className="text-white hover:bg-white/10 focus:bg-white/10 cursor-pointer flex items-center py-3"
-                    onClick={() => window.open('https://cabana.exchange/swap/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v-LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR?daoRef=Epicentral', '_blank')}
+                    onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank')}
                   >
                     <Image 
                       src="/cabana_logo.png" 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
                   </DropdownMenuItem>
                   <DropdownMenuItem 
                     className="text-white hover:bg-white/10 focus:bg-white/10 cursor-pointer flex items-center"
-                    onClick={() => window.open('https://cabana.exchange/swap/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v-LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR?daoRef=Epicentral', '_blank')}
+                    onClick={() => window.open('https://cabana.exchange/?partner=Epicentral', '_blank')}
                   >
                     <Image 
                       src="/cabana_logo.png" 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -59,7 +59,7 @@ export default function Footer() {
             </Link>
 
             <Link 
-              href="https://cabana.exchange/swap/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v-LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR?daoRef=Epicentral" 
+              href="https://cabana.exchange/?partner=Epicentral" 
               target="_blank"
               className="text-white/70 hover:text-white transition-all duration-300 
                          hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.3)]"


### PR DESCRIPTION
… parameter for improved tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all Cabana links to use the partner URL (https://cabana.exchange/?partner=Epicentral).
  * DAO page buttons now open the partner page instead of token-specific swap URLs.
  * Labs Token menu item and Footer Cabana link updated to the partner page.
  * Links continue to open in a new tab; no other UI or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->